### PR TITLE
Use the `server_suffix` option in guild creation

### DIFF
--- a/helpers.go
+++ b/helpers.go
@@ -1,33 +1,5 @@
 package main
 
-import (
-	"fmt"
-
-	"github.com/bwmarrin/discordgo"
-)
-
-type token struct{}
-
-func stringPtr(x string) *string {
+func toPtr[T any](x T) *T {
 	return &x
-}
-
-func interactionUser(event *discordgo.InteractionCreate) (*discordgo.User, error) {
-	var user *discordgo.User
-	if event.User != nil {
-		user = event.User
-	} else {
-		if event.Member == nil {
-			return nil, fmt.Errorf("interaction request recevied without any identified user: %+v", event)
-		}
-		user = event.Member.User
-	}
-	return user, nil
-}
-
-func username(u *discordgo.User) string {
-	if u.Discriminator != "0" {
-		return fmt.Sprintf("%s#%s", u.Username, u.Discriminator)
-	}
-	return u.Username
 }

--- a/list_servers.go
+++ b/list_servers.go
@@ -12,14 +12,9 @@ func init() {
 	commands["list-servers"] = command{&discordgo.ApplicationCommand{Description: "Lists all servers that the bot owns"}, listServers}
 }
 
-func listServers(s *discordgo.Session, event *discordgo.InteractionCreate) {
-	user, err := interactionUser(event)
-	if err != nil {
-		glog.Error(err)
-		return
-	}
-	username := username(user)
-	glog.Infof("list guilds request received from %q", username)
+func listServers(s *discordgo.Session, interaction *discordgo.Interaction, user *discordgo.User, options map[string]*discordgo.ApplicationCommandInteractionDataOption) {
+	glog.Infof("list guilds request received from %q", user)
+
 	s.State.RLock()
 	var guilds []string
 	for _, guild := range s.State.Guilds {
@@ -28,13 +23,14 @@ func listServers(s *discordgo.Session, event *discordgo.InteractionCreate) {
 		}
 	}
 	s.State.RUnlock()
+
 	var content string
 	if len(guilds) == 0 {
 		content = "I do not own any servers."
 	} else {
 		content = strings.Join(guilds, "\n")
 	}
-	if err := s.InteractionRespond(event.Interaction, &discordgo.InteractionResponse{
+	if err := s.InteractionRespond(interaction, &discordgo.InteractionResponse{
 		Type: discordgo.InteractionResponseChannelMessageWithSource,
 		Data: &discordgo.InteractionResponseData{
 			Content: content,
@@ -44,5 +40,5 @@ func listServers(s *discordgo.Session, event *discordgo.InteractionCreate) {
 		glog.Errorf("failed to respond to interaction request: %v", err)
 		return
 	}
-	glog.Infof("sent guild list to %q", username)
+	glog.Infof("sent guild list to %q", user)
 }


### PR DESCRIPTION
* Make toPtr generic rather than string specific
* Move user detection to the main ApplicationCommand handler and send that to the sub-handlers directly
* Process ApplicationCommand options into a map keyed on option name and send that to the sub-handlers to reduce boilerplate